### PR TITLE
Hard coded replaced with parameter

### DIFF
--- a/HMLauncherView/HMLauncherView.m
+++ b/HMLauncherView/HMLauncherView.m
@@ -285,7 +285,7 @@ static const CGFloat kLongPressDuration = 0.3;
     // LongPress gesture
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self 
                                                                                             action:@selector(didLongPressIcon:withEvent:)];
-    [longPress setMinimumPressDuration:0.4];
+    [longPress setMinimumPressDuration:duration];
     if (recognizerToFail != nil) {
         [longPress requireGestureRecognizerToFail:recognizerToFail];
     }


### PR DESCRIPTION
Replaced the 0.4 hardcoded 'minimumPressDuration' with the intended 'duration' parameter
