### PR TITLE
Removed asserts breaking for some subclasses

### DIFF
--- a/HMLauncherView/HMLauncherIcon.m
+++ b/HMLauncherView/HMLauncherIcon.m
@@ -19,11 +19,8 @@
 @implementation HMLauncherIcon
 
 - (BOOL) hitCloseButton:(CGPoint)point {
-    NSAssert(NO, @"this method must be overridden");
+    // to be overridden in subclass
     return NO;
-}
-- (void) drawRect:(CGRect) rect {
-    NSAssert(NO, @"this method must be overridden");
 }
 
 - (void) setHighlighted:(BOOL)highlighted {


### PR DESCRIPTION
Drawing views via `drawRect:` is CPU-based and inferior to GPU-based CALayer-styles.
As such it's a common pattern to style views via CALayers. Implementing `drawRect:` and even more so adding an assert to it prevents that.
