### PR TITLE
Expose the keyView as a property 

### DIFF
--- a/Classes/HMLauncherView.h
+++ b/Classes/HMLauncherView.h
@@ -55,5 +55,6 @@
 @property (nonatomic, weak) NSObject<HMLauncherDataSource> *dataSource;
 @property (nonatomic, weak) NSObject<HMLauncherViewDelegate> *delegate;
 @property (nonatomic, strong) NSString *persistKey;
+@property (nonatomic, weak) UIView *keyView;
 
 @end

--- a/Classes/HMLauncherView.m
+++ b/Classes/HMLauncherView.m
@@ -150,6 +150,11 @@ static const CGFloat kLongPressDuration = 0.3;
 }
 
 - (UIView *) keyView {
+    
+    if (_keyView) {
+        return _keyView;
+    }
+    
 	UIWindow *w = [[UIApplication sharedApplication] keyWindow];
 	if (w.subviews.count > 0) {
 		return [w.subviews lastObject];


### PR DESCRIPTION
Expose the keyView as a property and fallback to the last view on the window hierarchy when it's not set.

If the view hierarchy has a complex structure and the top view on the window is not always the one we want our icons to be added on, there is a need to supply our own target view. 

In my case, I had a floating element that was at times hidden- when that happened and an icon was dragged, the icon disappeared. Being able to supply my own keyView fixed the problem.
